### PR TITLE
PartyResults data update refactor

### DIFF
--- a/components/Steps/CandidateResults/index.js
+++ b/components/Steps/CandidateResults/index.js
@@ -54,19 +54,20 @@ export default function Step4(props) {
   if (!router.query.partyName) {
     router.push('/');
   }
+  const partyName = router.query.partyName;
 
   const [isFilterModalOpen, setFilterModalState] = useState(false);
   const [filters, setFilters] = useState(ls('op.wizard').filters);
-  const candidates = ls('op.wizard').filteredCandidates[
-    toggleSlug(router.query.partyName)
-  ];
+  const candidates = ls('op.wizard').filteredCandidates[toggleSlug(partyName)];
   const location = ls('op.wizard').location;
 
   const { data, error } = useSWR(
-    candidates && location ? '/api/parties/dirtylists' : null,
+    location
+      ? `/api/parties/dirtylists?region=${location}&party=${partyName}`
+      : null,
     () =>
       fetch(
-        `${process.env.api.partiesUrl}/dirtylists?region=${location}&party=${candidates[0].org_politica_nombre}`,
+        `${process.env.api.partiesUrl}/dirtylists?region=${location}&party=${partyName}`,
       ).then((data) => data.json()),
   );
 
@@ -120,9 +121,7 @@ export default function Step4(props) {
           </Styled.Emphasis>{' '}
           posibles candidatos {candidates ? 'de' : ''}{' '}
           <Styled.Emphasis>
-            {startCasePeruvianRegions(
-              candidates ? candidates[0].org_politica_nombre : '',
-            )}
+            {startCasePeruvianRegions(candidates ? partyName : '')}
           </Styled.Emphasis>
         </Styled.Title>
         <Styled.ChipCard type="good">

--- a/components/Steps/CandidateResults/index.js
+++ b/components/Steps/CandidateResults/index.js
@@ -58,22 +58,20 @@ export default function Step4(props) {
 
   const [isFilterModalOpen, setFilterModalState] = useState(false);
   const [filters, setFilters] = useState(ls('op.wizard').filters);
-  const candidates = ls('op.wizard').filteredCandidates[toggleSlug(partyName)];
+  const candidates = ls('op.wizard').filteredCandidates[
+    toggleSlug(router.query.partyName)
+  ];
   const location = ls('op.wizard').location;
 
   const { data, error } = useSWR(
-    location
-      ? `/api/parties/dirtylists?region=${location}&party=${partyName}`
+    candidates && location
+      ? `/api/parties/dirtylists?region=${location}&party=${candidates[0].org_politica_nombre}`
       : null,
     () =>
       fetch(
-        `${process.env.api.partiesUrl}/dirtylists?region=${location}&party=${partyName}`,
+        `${process.env.api.partiesUrl}/dirtylists?region=${location}&party=${candidates[0].org_politica_nombre}`,
       ).then((data) => data.json()),
   );
-
-  if (!data) {
-    return <LoadingScreen />;
-  }
 
   const listIssues = data?.data?.lists[0];
   const badIssues = listIssues
@@ -121,20 +119,22 @@ export default function Step4(props) {
           </Styled.Emphasis>{' '}
           posibles candidatos {candidates ? 'de' : ''}{' '}
           <Styled.Emphasis>
-            {startCasePeruvianRegions(candidates ? partyName : '')}
+            {startCasePeruvianRegions(
+              candidates ? candidates[0].org_politica_nombre : '',
+            )}
           </Styled.Emphasis>
         </Styled.Title>
         <Styled.ChipCard type="good">
           Recuerda que tu voto por este partido beneficia a los primeros de su
           lista al congreso.
         </Styled.ChipCard>
-        {badIssues ? (
+        {candidates && badIssues ? (
           <Styled.ChipCard type="bad">
             Alguno de los primeros de esta lista tiene{' '}
             <strong>sentencias y/o sanciones en SERVIR.</strong>
           </Styled.ChipCard>
         ) : null}
-        {infoIssues ? (
+        {candidates && infoIssues ? (
           <Styled.ChipCard type="info">
             Alguno de los primeros de esta lista tiene{' '}
             <strong>deudas con SUNAT y/o infracciones de tránsito.</strong>

--- a/components/Steps/PartyResults/index.js
+++ b/components/Steps/PartyResults/index.js
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import useSWR from 'swr';
 import fetch from 'isomorphic-fetch';
 import ls from 'local-storage';
@@ -49,12 +49,13 @@ const LoadingScreen = () => {
 
 const groupCandidatesByPartyNameAndLS = (candidates, keyName) => {
   const groupedCandidates = groupBy(candidates, 'org_politica_nombre');
-  ls('op.wizard', { ...ls('op.wizard'), [keyName]: groupedCandidates });
+  if (keyName) {
+    ls('op.wizard', { ...ls('op.wizard'), [keyName]: groupedCandidates });
+  }
   return groupedCandidates;
 };
 
-const showPartyCards = () => {
-  const candidatesByPartyName = ls('op.wizard').filteredCandidates;
+const showPartyCards = (candidatesByPartyName) => {
   return Object.keys(candidatesByPartyName).map((partyName) => (
     <PartyCard
       key={partyName}
@@ -64,16 +65,6 @@ const showPartyCards = () => {
       candidates={candidatesByPartyName[partyName]}
     />
   ));
-};
-
-const fetchCandidates = () => {
-  const apiTerms = qs.stringify(mapApiTerms(ls('op.wizard')));
-  const { data, error } = useSWR(`/api/candidates/${JSON.stringify(apiTerms)}`, () =>
-    fetch(`${process.env.api.candidatesUrl}?${apiTerms}`).then((data) =>
-      data.json(),
-    ),
-  );
-  return data;
 };
 
 const fetchSeats = (location) => {
@@ -86,28 +77,61 @@ const fetchSeats = (location) => {
 };
 
 export default function PartyResults(props) {
+  // initializa candidates state, populate with filteredCandidates if exists
+  const [candidates, setCandidates] = useState({});
+  const [isFilterModalOpen, setFilterModalState] = useState(false);
+  const [filters, setFilters] = useState(ls('op.wizard')?.filters || []);
+
   const isServer = typeof window === 'undefined';
   if (isServer) {
     return <LoadingScreen />;
   }
 
-  const [isFilterModalOpen, setFilterModalState] = useState(false);
-  const data = fetchCandidates();
-  ls('op.wizard', { ...ls('op.wizard'), rawCandidates: data?.data.candidates });
+  const fetchStoreCandidates = async () => {
+    // vacancia path step 1: refreshes from API
+    const response = await fetch(
+      `${process.env.api.candidatesUrl}?${apiTerms}`,
+    );
+    const data = await response.json();
+
+    //// apply filters to candidates if filters exist
+    const fetchedCandidates = (await filters.length)
+      ? applyFilters(data?.data.candidates)(filters)
+      : data?.data.candidates;
+
+    // vacancia path step 2: update local candidates state with filters when applicable
+    setCandidates(groupCandidatesByPartyNameAndLS(fetchedCandidates));
+
+    // vacancia path step 3: refresh local storage information
+    //// store new rawCandidates (never filtered!)
+    ls('op.wizard', {
+      ...ls('op.wizard'),
+      rawCandidates: data?.data.candidates,
+    });
+    //// group and store new filteredcandidates
+    groupCandidatesByPartyNameAndLS(fetchedCandidates, 'filteredCandidates');
+  };
+
+  const apiTerms = qs.stringify(mapApiTerms(ls('op.wizard')));
+
+  // Data refresh hooks
+  useEffect(() => {
+    // vacancia path: refresh "candidates" state!
+    fetchStoreCandidates();
+  }, []);
+
+  useEffect(() => {
+    // internal path, whenever filters change:
+    //// update "candidates" state based on filters!
+    //// FilterModal takes care of updating local storage
+    setCandidates(ls('op.wizard').filteredCandidates);
+  }, [filters]);
+
   const location = ls('op.wizard').location;
   const seats = fetchSeats(location);
-  const [filters, setFilters] = useState(ls('op.wizard')?.filters || []);
 
-  if (!data || !seats) {
+  if (!candidates || !seats) {
     return <LoadingScreen />;
-  }
-
-  groupCandidatesByPartyNameAndLS(ls('op.wizard').rawCandidates, 'candidates');
-  if (!ls('op.wizard').filteredCandidates) {
-    groupCandidatesByPartyNameAndLS(
-      ls('op.wizard').rawCandidates,
-      'filteredCandidates',
-    );
   }
 
   return (
@@ -143,7 +167,7 @@ export default function PartyResults(props) {
           <strong>{simplePluralize(seats?.data?.seats, 'sitio')}</strong> en el
           congreso.
         </Styled.Chip>
-        <Styled.Results>{showPartyCards()}</Styled.Results>
+        <Styled.Results>{showPartyCards(candidates)}</Styled.Results>
       </Styled.Step>
     </Styled.Container>
   );


### PR DESCRIPTION
- PartyResults: new strategy to update data based on useEffect and two different paths
- CandidateResults: stop relying on candidates for party name
- High level explanation:
![image](https://user-images.githubusercontent.com/10046142/107385882-51e31100-6ac1-11eb-917c-8c53334abfdd.png)
