### PR TITLE
Hide checkboxes for the Tag component

### DIFF
--- a/components/FilterModal/styles.js
+++ b/components/FilterModal/styles.js
@@ -33,6 +33,7 @@ export const Tag = styled('input').attrs((props) => ({
   type: 'checkbox',
 }))`
   appearance: none;
+  display: none;
 `;
 
 export const TagLabel = styled('label')`


### PR DESCRIPTION
This way they won't show up on iOS' Safari.

closes #95 