### PR TITLE
Favorites page

### DIFF
--- a/components/CandidateCard/styles.js
+++ b/components/CandidateCard/styles.js
@@ -1,6 +1,11 @@
 import styled from 'styled-components';
 import Image from 'next/image';
 
+const borderPriority = {
+  primary: '#c7cad1',
+  secondary: '#4EB5A2',
+};
+
 export const PartyIcon = styled(Image).attrs((props) => ({
   height: 32,
   width: 32,
@@ -33,7 +38,7 @@ export const Fullname = styled('p')`
 export const Card = styled('div')`
   align-items: center;
   border-radius: 4px;
-  border: 1px solid #c7cad1;
+  border: 1px solid ${props => borderPriority[props.type || 'primary']};
   cursor: pointer;
   display: flex;
   gap: 0.25rem;
@@ -45,7 +50,7 @@ export const Card = styled('div')`
 `;
 
 export const ArrowCircle = styled('div')`
-  background: #F3F8F7 url("/images/icons/right-arrow.svg") no-repeat center;
+  background: #f3f8f7 url('/images/icons/right-arrow.svg') no-repeat center;
   border-radius: 100%;
   height: 1.5rem;
   position: absolute;

--- a/components/Favorites/index.js
+++ b/components/Favorites/index.js
@@ -1,0 +1,71 @@
+import { useContext } from 'react';
+import Router from 'next/router';
+import ls from 'local-storage';
+import { FavoritesContext } from 'hooks/useFavorites';
+import GoBackButton from 'components/GoBackButton';
+import Chip from 'components/Chip';
+import * as Styled from './styles';
+
+const includesAll = (theseValues) => (inTheseValues) =>
+  theseValues.every((value) => inTheseValues.includes(value));
+
+const comesFromAFinishedUserTrip = includesAll([
+  'location',
+  'impeachment',
+  'withSentence',
+])(Object.keys(ls.get('op.wizard')));
+
+const onKeepLookingButtonClick = (event) => {
+  if (comesFromAFinishedUserTrip) {
+    Router.push('/results/grouped-by-party');
+    return;
+  }
+  Router.push('/');
+};
+
+const onGoBackButtonClick = (event) => {
+  if (comesFromAFinishedUserTrip) {
+    Router.back();
+    return;
+  }
+  Router.push('/');
+};
+
+export default function Favorites(props) {
+  const { favorites } = useContext(FavoritesContext);
+
+  return (
+    <Styled.Container>
+      <Styled.Header />
+      <Styled.Step>
+        <Styled.Row>
+          <GoBackButton
+            text={comesFromAFinishedUserTrip ? 'Regresa' : 'Ir al Home'}
+            onClick={onGoBackButtonClick}
+          />
+        </Styled.Row>
+        <Styled.Title>Mis candidatxs favoritxs</Styled.Title>
+        <Styled.Candidates>
+          {favorites.length ? (
+            favorites.map((favorite, index) => (
+              <Styled.CandidateCard
+                key={`Candidate-${index}`}
+                candidateParty={favorite.org_politica_nombre}
+                candidateNumber={favorite.posicion}
+                candidateFullname={`${favorite.id_nombres} ${favorite.id_apellido_paterno}`}
+                profileImageId={favorite.hoja_vida_id}
+                systemId={favorite.hoja_vida_id}
+              />
+            ))
+          ) : (
+            <Chip type={'info'}>Todavía no tienes candidatxs favoritxs.</Chip>
+          )}
+        </Styled.Candidates>
+        <Styled.KeepLookingButton
+          text="Sigue buscando"
+          onClick={onKeepLookingButtonClick}
+        />
+      </Styled.Step>
+    </Styled.Container>
+  );
+}

--- a/components/Favorites/index.js
+++ b/components/Favorites/index.js
@@ -50,6 +50,7 @@ export default function Favorites(props) {
             favorites.map((favorite, index) => (
               <Styled.CandidateCard
                 key={`Candidate-${index}`}
+                type="secondary"
                 candidateParty={favorite.org_politica_nombre}
                 candidateNumber={favorite.posicion}
                 candidateFullname={`${favorite.id_nombres} ${favorite.id_apellido_paterno}`}

--- a/components/Favorites/styles.js
+++ b/components/Favorites/styles.js
@@ -1,0 +1,48 @@
+import styled from 'styled-components';
+import BaseHeader from 'components/Header';
+import BaseTitle from 'components/BaseTitle';
+import BaseCandidateCard from 'components/CandidateCard';
+import BaseButton from 'components/BaseButton';
+
+export const Container = styled('section')`
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+`;
+
+export const Header = styled(BaseHeader)`
+  width: 100%;
+`;
+
+export const Step = styled('div')`
+  align-items: center;
+  flex-direction: column;
+  display: flex;
+  min-height: 100vh;
+  padding: 1.5rem;
+`;
+
+export const Row = styled.div`
+  display: flex;
+  width: 100%;
+  justify-content: space-between;
+`;
+
+export const Title = styled(BaseTitle)`
+  margin-top: 2rem;
+`;
+
+export const Candidates = styled('section')`
+  margin-top: 0.5rem;
+`;
+
+export const CandidateCard = styled(BaseCandidateCard)`
+  margin-bottom: 0.5rem;
+`;
+
+// Todo: make it sticky / position-absoluted when needed
+export const KeepLookingButton = styled((props) => (
+  <BaseButton type="secondary" {...props} />
+))`
+  margin-top: 1.25rem;
+`;

--- a/hooks/useFavorites/index.js
+++ b/hooks/useFavorites/index.js
@@ -1,0 +1,49 @@
+import { createContext } from 'react';
+import { usePersistedReducer } from 'hooks/usePersistedReducer';
+
+export const FavoritesContext = createContext();
+
+const initialFavoritesState = {
+  data: [],
+};
+
+const reducer = (state, action) => {
+  if (action.type === 'addFavorite') {
+    return { data: [...state.data, action.value] };
+  }
+  if (action.type === 'removeFavoriteBySystemId') {
+    const favoriteIndex = state.data.findIndex(
+      (favorite) => favorite.hoja_vida_id === action.value,
+    );
+    return {
+      data: [
+        ...state.data.slice(0, favoriteIndex),
+        ...state.data.slice(favoriteIndex + 1),
+      ],
+    };
+  }
+  if (action.type === 'resetFavorites') {
+    return initialFavoritesState;
+  }
+};
+
+export const FavoritesProvider = ({ children }) => {
+  const [state, dispatch] = usePersistedReducer(
+    reducer,
+    'op.favorites',
+    initialFavoritesState,
+  );
+
+  return (
+    <FavoritesContext.Provider
+      value={{
+        favorites: state.data,
+        addFavorite: (value) => dispatch({ type: 'addFavorite', value }),
+        removeFavoriteBySystemId: (value) =>
+          dispatch({ type: 'removeFavoriteBySystemId', value }),
+        resetFavorites: (value) => dispatch({ type: 'resetFavorites' }),
+      }}>
+      {children}
+    </FavoritesContext.Provider>
+  );
+};

--- a/hooks/usePersistedReducer/index.js
+++ b/hooks/usePersistedReducer/index.js
@@ -1,0 +1,13 @@
+import { useEffect, useReducer } from 'react';
+import ls from 'local-storage';
+
+export function usePersistedReducer(reducer, key, initialState) {
+  const init = ls(key) || initialState;
+  const [state, dispatch] = useReducer(reducer, init);
+
+  useEffect(() => {
+    ls(key, state);
+  }, [key, state]);
+
+  return [state, dispatch];
+}

--- a/pages/favorites/index.js
+++ b/pages/favorites/index.js
@@ -1,0 +1,13 @@
+import dynamic from 'next/dynamic';
+import { FavoritesProvider } from 'hooks/useFavorites';
+
+const Favorites = dynamic(() => import('components/Favorites'), {
+  ssr: false,
+});
+
+const nossrFavorites = () => (
+  <FavoritesProvider>
+    <Favorites />
+  </FavoritesProvider>
+);
+export default nossrFavorites;


### PR DESCRIPTION
closes #136 

Agrega la pantalla de Favoritxs
<img width="1280" alt="Screen Shot 2021-02-27 at 22 34 40" src="https://user-images.githubusercontent.com/324686/109408107-672abd00-7954-11eb-95fe-844576fd43ca.png">

Crea una nueva llave en LocalStorage llamado `op.favorites` de su existencia depende que se muestra en esta sección.
Todavía no hay una manera de agregar Favoritxs, pero ahí aparecerían.

También se maneja regresar al home o continuar "el viaje" cuando el usuario tiene variables en LocalStorage.
