### PR TITLE
Self-hosted Matomo

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -14,7 +14,7 @@ module.exports = {
       version: 6,
     },
     matomo: {
-      url: 'https://votupe.matomo.cloud/',
+      url: 'http://analytics.openpolitica.com/',
       siteId: 1,
     },
   },

--- a/next.config.js
+++ b/next.config.js
@@ -14,7 +14,7 @@ module.exports = {
       version: 6,
     },
     matomo: {
-      url: 'http://analytics.openpolitica.com/',
+      url: 'https://matomo.openpolitica.com/',
       siteId: 1,
     },
   },


### PR DESCRIPTION
@redsii @wixo está listo el Matomo.
Debido a las múltiples pruebas, sin darme cuenta excedí la renovación de certificados permitida y perdimos el HTTPS temporalmente, por lo que estaríamos con solo HTTP por 1 semana. La alternativa para recuperar el HTTPS sin esperar, es cambiarnos de analytics.openpolitica.com a cualquierotracosa.openpolitica.com (puede ser matomo.open...)