### PR TITLE
Add some filters

### DIFF
--- a/components/FilterModal/index.js
+++ b/components/FilterModal/index.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import ls from 'local-storage';
 import groupBy from 'lodash.groupby';
 import Image from 'next/image';

--- a/components/FilterModal/index.js
+++ b/components/FilterModal/index.js
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import ls from 'local-storage';
 import groupBy from 'lodash.groupby';
 import Image from 'next/image';
@@ -67,6 +67,13 @@ const FilterModal = (props) => {
   const [educationState, setEducationState] = useState(
     initializeEducationState(props.filters),
   );
+  const [isMilitantMemberState, setMilitantMemberState] = useState(
+    props.filters.includes('isMilitantMember'),
+  );
+  const [isGuestMemberState, setGuestMemberState] = useState(
+    props.filters.includes('isGuestMember'),
+  );
+
   const [hasPublicServiceExperience, setPublicServiceExperience] = useState(
     props.filters.includes('hasPublicServiceExperience'),
   );
@@ -268,6 +275,59 @@ const FilterModal = (props) => {
                 toggleEducationFilter(props.filters)('upToPostgraduate'),
               )
             }
+          />
+        </Styled.CheckboxRow>
+      </Styled.ModalSection>
+      <Styled.ModalSection>
+        <Styled.FilterTitle>Estado en el partido</Styled.FilterTitle>
+        <Styled.CheckboxRow>
+          <Styled.CheckboxLabel htmlFor="militant">
+            Ver militantes del partido
+          </Styled.CheckboxLabel>
+          <Styled.Checkbox
+            id="militant"
+            name="militant"
+            isChecked={isMilitantMemberState}
+            onClick={() => {
+              if (isGuestMemberState) {
+                setMilitantMemberState(!isMilitantMemberState);
+                setGuestMemberState(!isGuestMemberState);
+                props.setFilters((prevFilters) => [
+                  ...prevFilters.filter((f) => f !== 'isGuestMember'),
+                  'isMilitantMember',
+                ]);
+              } else {
+                toggle(setMilitantMemberState)(isMilitantMemberState) ||
+                  props.setFilters(
+                    toggleFilter(props.filters)('isMilitantMember'),
+                  );
+              }
+            }}
+          />
+        </Styled.CheckboxRow>
+        <Styled.CheckboxRow>
+          <Styled.CheckboxLabel htmlFor="guest">
+            Ver invitados del partido
+          </Styled.CheckboxLabel>
+          <Styled.Checkbox
+            id="guest"
+            name="guest"
+            isChecked={isGuestMemberState}
+            onClick={() => {
+              if (isMilitantMemberState) {
+                setMilitantMemberState(!isMilitantMemberState);
+                setGuestMemberState(!isGuestMemberState);
+                props.setFilters((prevFilters) => [
+                  ...prevFilters.filter((f) => f !== 'isMilitantMember'),
+                  'isGuestMember',
+                ]);
+              } else {
+                toggle(setGuestMemberState)(isGuestMemberState) ||
+                  props.setFilters(
+                    toggleFilter(props.filters)('isGuestMember'),
+                  );
+              }
+            }}
           />
         </Styled.CheckboxRow>
       </Styled.ModalSection>

--- a/components/FilterModal/index.js
+++ b/components/FilterModal/index.js
@@ -110,7 +110,7 @@ const FilterModal = (props) => {
           <Image src="/images/icons/filter-x.svg" width="14" height="14" />
         </Styled.CloseButton>
       </Styled.Header>
-      <Styled.GenreSection>
+      <Styled.TagSection>
         <Styled.FilterTitle>Género</Styled.FilterTitle>
         <Styled.Tag name="female" id="female" />
         <Styled.TagLabel
@@ -150,7 +150,7 @@ const FilterModal = (props) => {
           htmlFor="male">
           Solo hombres
         </Styled.TagLabel>
-      </Styled.GenreSection>
+      </Styled.TagSection>
       <Styled.ModalSection>
         <Styled.FilterTitle>Experiencia declarada</Styled.FilterTitle>
         <Styled.CheckboxRow>
@@ -278,7 +278,7 @@ const FilterModal = (props) => {
           />
         </Styled.CheckboxRow>
       </Styled.ModalSection>
-      <Styled.GenreSection>
+      <Styled.TagSection>
         <Styled.FilterTitle>Estado en el partido</Styled.FilterTitle>
         <Styled.Tag name="militant" id="militant" />
         <Styled.TagLabel
@@ -316,7 +316,7 @@ const FilterModal = (props) => {
           htmlFor="guest">
           Solo Invitados
         </Styled.TagLabel>
-      </Styled.GenreSection>
+      </Styled.TagSection>
       <Styled.ModalSection>
         <Styled.FilterTitle>Sanciones e Infracciones</Styled.FilterTitle>
         <Styled.CheckboxRow>

--- a/components/FilterModal/index.js
+++ b/components/FilterModal/index.js
@@ -278,59 +278,45 @@ const FilterModal = (props) => {
           />
         </Styled.CheckboxRow>
       </Styled.ModalSection>
-      <Styled.ModalSection>
+      <Styled.GenreSection>
         <Styled.FilterTitle>Estado en el partido</Styled.FilterTitle>
-        <Styled.CheckboxRow>
-          <Styled.CheckboxLabel htmlFor="militant">
-            Ver militantes del partido
-          </Styled.CheckboxLabel>
-          <Styled.Checkbox
-            id="militant"
-            name="militant"
-            isChecked={isMilitantMemberState}
-            onClick={() => {
-              if (isGuestMemberState) {
-                setMilitantMemberState(!isMilitantMemberState);
-                setGuestMemberState(!isGuestMemberState);
-                props.setFilters((prevFilters) => [
-                  ...prevFilters.filter((f) => f !== 'isGuestMember'),
-                  'isMilitantMember',
-                ]);
-              } else {
-                toggle(setMilitantMemberState)(isMilitantMemberState) ||
-                  props.setFilters(
-                    toggleFilter(props.filters)('isMilitantMember'),
-                  );
-              }
-            }}
-          />
-        </Styled.CheckboxRow>
-        <Styled.CheckboxRow>
-          <Styled.CheckboxLabel htmlFor="guest">
-            Ver invitados del partido
-          </Styled.CheckboxLabel>
-          <Styled.Checkbox
-            id="guest"
-            name="guest"
-            isChecked={isGuestMemberState}
-            onClick={() => {
-              if (isMilitantMemberState) {
-                setMilitantMemberState(!isMilitantMemberState);
-                setGuestMemberState(!isGuestMemberState);
-                props.setFilters((prevFilters) => [
-                  ...prevFilters.filter((f) => f !== 'isMilitantMember'),
-                  'isGuestMember',
-                ]);
-              } else {
-                toggle(setGuestMemberState)(isGuestMemberState) ||
-                  props.setFilters(
-                    toggleFilter(props.filters)('isGuestMember'),
-                  );
-              }
-            }}
-          />
-        </Styled.CheckboxRow>
-      </Styled.ModalSection>
+        <Styled.Tag name="militant" id="militant" />
+        <Styled.TagLabel
+          checked={isMilitantMemberState}
+          onClick={() => {
+            setMilitantMemberState(!isMilitantMemberState);
+            if (isGuestMemberState) {
+              setGuestMemberState(!isGuestMemberState);
+              props.setFilters((prevFilters) => [
+                ...prevFilters.filter((f) => f !== 'isGuestMember'),
+                'isMilitantMember',
+              ]);
+            } else {
+              props.setFilters(toggleFilter(props.filters)('isMilitantMember'));
+            }
+          }}
+          htmlFor="militant">
+          Solo Militantes
+        </Styled.TagLabel>
+        <Styled.Tag name="guest" id="guest" />
+        <Styled.TagLabel
+          checked={isGuestMemberState}
+          onClick={() => {
+            setGuestMemberState(!isGuestMemberState);
+            if (isMilitantMemberState) {
+              setMilitantMemberState(!isMilitantMemberState);
+              props.setFilters((prevFilters) => [
+                ...prevFilters.filter((f) => f !== 'isMilitantMember'),
+                'isGuestMember',
+              ]);
+            } else {
+              props.setFilters(toggleFilter(props.filters)('isGuestMember'));
+            }
+          }}
+          htmlFor="guest">
+          Solo Invitados
+        </Styled.TagLabel>
+      </Styled.GenreSection>
       <Styled.ModalSection>
         <Styled.FilterTitle>Sanciones e Infracciones</Styled.FilterTitle>
         <Styled.CheckboxRow>

--- a/components/FilterModal/styles.js
+++ b/components/FilterModal/styles.js
@@ -33,7 +33,7 @@ export const ApplyFiltersButton = styled(StyledButton)`
   padding: 0 0.75rem;
 `;
 
-export const GenreSection = styled('section')`
+export const TagSection = styled('section')`
   border-bottom: 1px solid #f1f2f3;
   height: 7.125rem;
   padding: 1.5rem;

--- a/components/Steps/PartyResults/filters.js
+++ b/components/Steps/PartyResults/filters.js
@@ -37,6 +37,12 @@ export const upToSecondary = (data) => byStudies(data, 'secundaria');
 export const upToHighSchool = (data) => byStudies(data, 'superior');
 export const upToPostgraduate = (data) => byStudies(data, 'postgrado');
 
+// Member state section
+export const isMilitantMember = (candidates) =>
+  candidates.filter((candidate) => candidate.designado === 'No');
+export const isGuestMember = (candidates) =>
+  candidates.filter((candidate) => candidate.designado === 'Sí');
+
 // Sanctions section
 export const doesntHaveSanctionsWithSunat = (candidates) =>
   candidates.filter((candidate) => candidate.deuda_sunat === 0);
@@ -61,6 +67,8 @@ const filterMap = {
   upToSecondary,
   upToHighSchool,
   upToPostgraduate,
+  isMilitantMember,
+  isGuestMember,
   doesntHaveSanctionsWithSunat,
   doesntHaveSanctionsWithServir,
   doesntHaveSanctionsWithDriving,


### PR DESCRIPTION
Closes https://github.com/openpolitica/open-wizard/issues/154

Note: 
- Tenemos una logica donde se aplican todos los filtros mediante un reduce, pero en el caso de que si es Militante or Invitado depende de una sola prop que es `designado` con valores de `Sí` o `No` .  Entonces cuando se activen los dos checkboxs no mostraria nada ya que ningun candidate cumpliria con esos dos opciones de filtros. 
 IMO, podriamos tener ambas opciones como excluyentes , lo cual tendria sentido porque un candidato no podria ser `Invitado` y a la vez `Militante`  

Que te piensas sobre ello, @wixo? 