### PR TITLE
change useEffect behavior to run once

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -22,7 +22,7 @@ const withHotjar = (Component) => (props) => {
 
   useEffect(() => {
     initHotjar(process.env.hotjar.id, process.env.hotjar.version, logger);
-  });
+  }, []);
 
   return <Component {...props} />;
 };
@@ -33,7 +33,7 @@ const withMatomo = (Component) => (props) => {
       url: process.env.matomo.url,
       siteId: process.env.matomo.siteId,
     });
-  });
+  }, []);
 
   return <Component {...props} />;
 };


### PR DESCRIPTION
Estamos implementando los useEffects que inicializan hotjar y matomo como para que corran con cada re-render en lugar de una sola vez. Esto podría estar causando el problema de Matomo, y alguna cosa en Hotjar.

UPDATE:
- Revisando la implementación de matomo-next, ellos usan componentDidMount así que este cambio está OK.
- Revisando la documentación de hotjar, ellos usan un useEffect sin condicional, o sea como lo teníamos (referencia [aquí](https://github.com/olavoparno/react-use-hotjar)), pero aún así no me hace sentido si sólo estamos inicializando el componente. Recomiendo probar con el cambio.