### PR TITLE
Fix: trim words with leading/trailing spaces

### DIFF
--- a/components/Accordion/processCandidateContent.js
+++ b/components/Accordion/processCandidateContent.js
@@ -1,7 +1,10 @@
 import hasDriverLicenseIssue from 'components/Steps/CandidateResults/hasDriverLicenseIssue';
 
 const capitalize = (text, { omit = ['de', 'en', 'el', 'la', 'del'] } = {}) => {
-  const lowerTextArray = text.toLowerCase().split(/\s+/);
+  const lowerTextArray = text
+    .trim()
+    .toLowerCase()
+    .split(/\s+/);
   return lowerTextArray
     .map((word) =>
       word !== lowerTextArray[0] && omit.includes(word)


### PR DESCRIPTION
Reproducción del bug: visitar https://votu.pe/candidate/134923.
Causa: Alguna palabra que entra a la función capitalize tiene espacios al inicio o final.
Arreglo: agregar trim() a la palabra/frase que entra en la función.