### PR TITLE
Redirect on no trip

### DIFF
--- a/components/Favorites/comesFromAFinishedUserTrip.js
+++ b/components/Favorites/comesFromAFinishedUserTrip.js
@@ -1,0 +1,11 @@
+import ls from 'local-storage';
+
+const includesAll = (theseValues) => (inTheseValues) =>
+  theseValues.every((value) => inTheseValues.includes(value));
+
+const comesFromAFinishedUserTrip = () =>
+  includesAll(['location', 'impeachment', 'withSentence'])(
+    Object.keys(ls.get('op.wizard') || {}),
+  );
+
+export default comesFromAFinishedUserTrip;

--- a/components/Favorites/index.js
+++ b/components/Favorites/index.js
@@ -1,19 +1,10 @@
 import { useContext } from 'react';
 import Router from 'next/router';
-import ls from 'local-storage';
 import { FavoritesContext } from 'hooks/useFavorites';
 import GoBackButton from 'components/GoBackButton';
 import Chip from 'components/Chip';
 import * as Styled from './styles';
-
-const includesAll = (theseValues) => (inTheseValues) =>
-  theseValues.every((value) => inTheseValues.includes(value));
-
-const comesFromAFinishedUserTrip = includesAll([
-  'location',
-  'impeachment',
-  'withSentence',
-])(Object.keys(ls.get('op.wizard')));
+import comesFromAFinishedUserTrip from './comesFromAFinishedUserTrip';
 
 const goBackToPartyResults = (event) => {
   if (comesFromAFinishedUserTrip) {

--- a/components/Steps/CandidateResults/index.js
+++ b/components/Steps/CandidateResults/index.js
@@ -1,9 +1,8 @@
-import { useEffect, useState, useContext } from 'react';
+import { useState, useContext } from 'react';
 import Router, { useRouter } from 'next/router';
 import useSWR from 'swr';
 import fetch from 'isomorphic-fetch';
 import ls from 'local-storage';
-import qs from 'qs';
 import { FavoritesContext } from 'hooks/useFavorites';
 import * as Styled from './styles';
 import toggleSlug from 'components/PartyCard/toggleSlug';
@@ -14,13 +13,10 @@ import FavoriteButton from 'components/FavoriteButton';
 import FilterModal from 'components/FilterModal';
 import {
   applyFilter,
-  applyFilters,
-  byGenre,
   onlyMale,
   onlyFemale,
   hasJNEIncome,
   hasPublicServiceExperience,
-  byStudies,
   upToPrimary,
   upToSecondary,
   upToHighSchool,
@@ -30,14 +26,7 @@ import {
   doesntHaveSanctionsWithDriving,
 } from 'components/Steps/PartyResults/filters';
 import hasDriverLicenseIssue from './hasDriverLicenseIssue';
-
-const mapApiTerms = (options) => ({
-  vacancia: options.impeachment,
-  sentencias: options.withSentence,
-  region: options.location,
-  role: 'CONGRESISTA',
-  limit: 10,
-});
+import comesFromAFinishedUserTrip from 'components/Favorites/comesFromAFinishedUserTrip';
 
 const LoadingScreen = () => {
   return (
@@ -56,10 +45,11 @@ export default function Step4(props) {
   if (isServer) {
     return <LoadingScreen />;
   }
-  if (!router.query.partyName) {
+
+  if (!router.query.partyName || !comesFromAFinishedUserTrip()) {
     router.push('/');
+    return null;
   }
-  const partyName = router.query.partyName;
 
   const [isFilterModalOpen, setFilterModalState] = useState(false);
   const [filters, setFilters] = useState(ls('op.wizard').filters);
@@ -68,7 +58,7 @@ export default function Step4(props) {
   ];
   const location = ls('op.wizard').location;
 
-  const { data, error } = useSWR(
+  const { data } = useSWR(
     candidates && location
       ? `/api/parties/dirtylists?region=${location}&party=${candidates[0].org_politica_nombre}`
       : null,

--- a/components/Steps/PartyResults/index.js
+++ b/components/Steps/PartyResults/index.js
@@ -13,13 +13,11 @@ import FilterModal from 'components/FilterModal';
 import {
   applyFilter,
   applyFilters,
-  byGenre,
   onlyMale,
   onlyFemale,
   hasJNEIncome,
   hasPublicServiceExperience,
   hasPrivateWorkExperience,
-  byStudies,
   upToPrimary,
   upToSecondary,
   upToHighSchool,
@@ -32,6 +30,7 @@ import GoBackButton from 'components/GoBackButton';
 import FavoriteButton from 'components/FavoriteButton';
 import startCasePeruvianRegions from './startCasePeruvianRegions';
 import simplePluralize from './simplePluralize';
+import comesFromAFinishedUserTrip from 'components/Favorites/comesFromAFinishedUserTrip';
 
 const mapApiTerms = (options) => ({
   vacancia: options.impeachment,
@@ -71,7 +70,7 @@ const showPartyCards = (candidatesByPartyName) => {
 };
 
 const fetchSeats = (location) => {
-  const { data, error } = useSWR('/api/locations/seats', () =>
+  const { data } = useSWR('/api/locations/seats', () =>
     fetch(`${process.env.api.locationsUrl}/${location}/seats`).then((data) =>
       data.json(),
     ),
@@ -89,6 +88,11 @@ export default function PartyResults(props) {
   const isServer = typeof window === 'undefined';
   if (isServer) {
     return <LoadingScreen />;
+  }
+
+  if (!comesFromAFinishedUserTrip()) {
+    Router.push('/');
+    return null;
   }
 
   const fetchStoreCandidates = async () => {


### PR DESCRIPTION
Graduamos la función que usamos en `/favorites` para redigir o no al home.
Hay unos updates de eslint.

Para testing visitar por ejemplo: https://votupe-git-redirect-on-no-trip-openpolitica.vercel.app/results/partido-morado en una ventana de incógnito, debería llevar al Home cc: @redsii 

closes #235
