### PR TITLE
Alternativa de solución para resetear respuestas

### DIFF
--- a/components/PresidentialQuizBreakdown/index.js
+++ b/components/PresidentialQuizBreakdown/index.js
@@ -23,13 +23,19 @@ const fetchQuestions = (apiTerms) =>
   );
 
 export default function PresidentialQuizBreakdown() {
-  const { userSelectedTopics, addQuizItems } = useTopics();
+  const { userSelectedTopics, addQuizItems, resetAnswers } = useTopics();
   const apiTerms = qs.stringify({ topics: userSelectedTopics });
   const { data: response, error, isLoading } = useSWR(
     '/api/policies/questions',
     () => fetchQuestions(apiTerms),
   );
   const questions = response?.data;
+
+  const handleContinueButton = () => {
+    resetAnswers();
+    Router.push('/presidential-steps/3');
+    return;
+  };
 
   useEffect(() => {
     addQuizItems(questions);
@@ -75,7 +81,7 @@ export default function PresidentialQuizBreakdown() {
             disabled={
               userSelectedTopics.length < requiredNumberOfSelectedTopics
             }
-            onClick={() => Router.push('/presidential-steps/3')}
+            onClick={handleContinueButton}
             text="Continuar"
           />
         </Styled.QuizBreakdown>

--- a/hooks/useTopics/index.js
+++ b/hooks/useTopics/index.js
@@ -51,6 +51,12 @@ const reducer = (state, action) => {
   if (action.type === 'resetTopics') {
     return initialTopicsState;
   }
+  if (action.type === 'resetAnswers') {
+    return {
+      ...state,
+      userAnswers: [],
+    };
+  }
 };
 
 export const TopicsProvider = ({ children }) => {
@@ -73,6 +79,7 @@ export const TopicsProvider = ({ children }) => {
         userAnswers: state.userAnswers,
         addUserAnswers: (value) => dispatch({ type: 'addUserAnswers', value }),
         resetTopics: () => dispatch({ type: 'resetTopics' }),
+        resetAnswers: () => dispatch({ type: 'resetAnswers' }),
       }}>
       {children}
     </TopicsContext.Provider>


### PR DESCRIPTION
El reset se produce antes de comenzar el cuestionario, solamente elimina respuestas anteriores, no modifica otras variables de context.