### PR TITLE
Hotfix: moves PA role evaluation to the end

### DIFF
--- a/components/CandidateBigCard/index.js
+++ b/components/CandidateBigCard/index.js
@@ -27,9 +27,6 @@ const contentPerCandidateType = (role, district, genre) => {
       ? `Postula por ${capitalize(district)}`
       : `Postula al Extranjero`;
   }
-  if (role.includes('PARLAMENTO ANDINO')) {
-    return 'Postula al parlamento andino';
-  }
   if (role.includes('PRESIDENTE')) {
     const specificRole = role.includes('PRIMER')
       ? '1ra Vicepresidencia'
@@ -39,6 +36,9 @@ const contentPerCandidateType = (role, district, genre) => {
     return genre === 'F'
       ? `Candidata a ${specificRole}`
       : `Candidato a ${specificRole}`;
+  }
+  if (role.includes('PARLAMENTO ANDINO')) {
+    return 'Postula al parlamento andino';
   }
 };
 


### PR DESCRIPTION
Corresponde con [este cambio de backend](https://github.com/openpolitica/open-politica-backend/pull/139) pero puede hacerse en cualquier momento, la idea es evaluar Parlamento Andino al final, para que los VP que son además PA, aparezcan como VPs.