### PR TITLE
Adiciona información en candidate_single cuando postula tanto a vicepresidente y parlamento andino

### DIFF
--- a/components/Steps/CandidateSingle/index.js
+++ b/components/Steps/CandidateSingle/index.js
@@ -94,6 +94,13 @@ export default function CandidateSingle(props) {
             } Vicepresidencia y al Congreso.`}
           </Styled.Chip>
         ) : null}
+        {c.cargo_nombre.includes('VICEPRESIDENTE Y REPRESENTANTE') ? (
+          <Styled.Chip type="good">
+            {`Este candidato está postulando a la ${
+              c.cargo_nombre.includes('PRIMER') ? 'Primera' : 'Segunda'
+            } Vicepresidencia y al Parlamento Andino.`}
+          </Styled.Chip>
+        ) : null}
         <Styled.CandidateBigCard
           addFavorite={addFavorite}
           removeFavorite={removeFavorite}


### PR DESCRIPTION
Adiciona el chip de información en la parte superior cuando postula a vicepresidente y parlamento andino.
![image](https://user-images.githubusercontent.com/6945270/113869389-49801d00-9776-11eb-8260-fe740985d552.png)
