### PR TITLE
Propuesta para actualizar título el día de las elecciones y cuando estas finalicen

### DIFF
--- a/components/HomePage/index.js
+++ b/components/HomePage/index.js
@@ -73,10 +73,57 @@ const HomePage = () => {
     router.push('/parliament-steps/1');
   };
 
-  const electionDate = new Date('2021/04/11');
+  const electionDateStart = new Date('2021/04/11 07:00 GMT-5:00');
+  const electionDateEnd = new Date('2021/04/11 19:00 GMT-5:00');
   const currentDate = new Date();
-  const miliseconds = electionDate.getTime() - currentDate.getTime();
-  const remainingDays = Math.round(miliseconds / (1000 * 60 * 60 * 24));
+  const miliseconds = electionDateStart.getTime() - currentDate.getTime();
+  const milisecondsEnd = electionDateEnd.getTime() - currentDate.getTime();
+  const remainingDays = Math.floor(miliseconds / (1000 * 60 * 60 * 24));
+  const remainingHours = Math.round(miliseconds / (1000 * 60 * 60));
+  const remainingHoursEnd = Math.round(milisecondsEnd / (1000 * 60 * 60));
+
+  const DynamicTime = () => {
+    if (remainingDays > 1) {
+      return <Styled.Emphasis> {remainingDays} días </Styled.Emphasis>;
+    }
+    if (remainingDays > 0) {
+      return <Styled.Emphasis> {remainingDays} día </Styled.Emphasis>;
+    }
+    if (remainingHours > 1) {
+      return <Styled.Emphasis> {remainingHours} horas </Styled.Emphasis>;
+    }
+    if (remainingHours > 0) {
+      return <Styled.Emphasis> {remainingHours} hora </Styled.Emphasis>;
+    }
+    if (remainingHoursEnd > 0) {
+      return null;
+    }
+  };
+
+  const DynamicTitle = () => {
+    if (remainingHours > 0) {
+      return (
+        <Styled.Title>
+          {remainingDays === 1 || remainingHours === 1 ? `Falta` : `Faltan`}
+          <DynamicTime />
+          para las elecciones <strong>¿Ya sabes por quién votar?</strong>
+        </Styled.Title>
+      );
+    }
+    if (remainingHoursEnd > 0) {
+      return (
+        <Styled.Title>
+          Hoy son las elecciones <strong>¿Ya sabes por quién votar?</strong>
+        </Styled.Title>
+      );
+    } else {
+      return (
+        <Styled.Title>
+          Las elecciones han finalizado, gracias por usar Votu.
+        </Styled.Title>
+      );
+    }
+  };
 
   useEffect(() => {
     resetTopics();
@@ -89,11 +136,7 @@ const HomePage = () => {
       <BaseHeader />
       <Styled.Hero>
         <Styled.TextContent>
-          <Styled.Title>
-            Faltan
-            <Styled.Emphasis> {remainingDays} días </Styled.Emphasis>
-            para las elecciones <strong>¿Ya sabes por quién votar?</strong>
-          </Styled.Title>
+          <DynamicTitle />
           <Styled.Paragraph>
             Te ayudamos a encontrar tus opciones para estas elecciones en unos
             cuantos pasos

--- a/components/HomePage/index.js
+++ b/components/HomePage/index.js
@@ -113,13 +113,14 @@ const HomePage = () => {
     if (remainingHoursEnd > 0) {
       return (
         <Styled.Title>
-          Hoy son las elecciones <strong>¿Ya sabes por quién votar?</strong>
+          El <strong>80% del Perú</strong> ya decidió por quién votar, ¿y tú?
         </Styled.Title>
       );
     } else {
       return (
         <Styled.Title>
-          Las elecciones han finalizado, gracias por usar Votu.
+          Las elecciones han finalizado. Gracias por usar{' '}
+          <strong>Votu.pe</strong>.
         </Styled.Title>
       );
     }


### PR DESCRIPTION
Propuesta incluye:
- Actualizar el tiempo a la zona horaria actual
- Considerar las horas restantes.
- Cambio de mensaje cuando es el día de las elecciones y después de estas.

OBS: Solo cuenta con textos provisionales, a la espera de datos definitivos por parte de diseño
Closes #335 